### PR TITLE
remove target_build_utils dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ documentation = "https://docs.rs/magnum-opus"
 linux-pkg-config = ["dep:pkg-config"]
 
 [build-dependencies]
-target_build_utils = "0.3"
 bindgen = "0.59"
 pkg-config = { version = "0.3.27", optional = true }


### PR DESCRIPTION
This pr is not necessary, only for simplify Cargo.lock.
https://github.com/nagisa/target_build_utils.rs DEPRECATED, it depend on serde 0.9.