### PR TITLE
add env VCPKG_INSTALLED_ROOT

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,11 @@ fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
         target = target.replace("x64", "x86");
     }
     println!("cargo:info={}", target);
-    path.push("installed");
+    if let Ok(vcpkg_root) = std::env::var("VCPKG_INSTALLED_ROOT") {
+        path = vcpkg_root.into();
+    } else {
+        path.push("installed");
+    }
     path.push(target);
     println!(
         "{}",


### PR DESCRIPTION
add env VCPKG_INSTALLED_ROOT

VCPKG_INSTALLED_ROOT used with vcpkg.json can be used with compiled dependencies in the project directory to make it easier to lock down versions